### PR TITLE
Proxy Support for Attack Surface Mapper

### DIFF
--- a/asm.py
+++ b/asm.py
@@ -965,7 +965,7 @@ if __name__ == "__main__":
 
     print_results(c1, start_time)  # Print terminal output
 
-    if args.proxy:
+    if args.proxy != "NoProxy":
         try:
             del os.environ['http_proxy']
             del os.environ['https_proxy']

--- a/asm.py
+++ b/asm.py
@@ -162,6 +162,7 @@ def init_checks(master_switch, outpath):
     parser.add_argument("-V", "--version", help="Displays the current version.", action="store_true", default=False)
     parser.add_argument("-w", "--wordlist", help="Specify a list of subdomains.", type=str,
                         default="resources/bitquark_top100k_sublist.txt")
+    parser.add_argument("-p", "--proxy", help="Provide a HTTP Proxy for requests",dest='proxy', type=str,default="NoProxy")
     parser.add_argument("-sw", "--subwordlist", help="Specify a list of child subdomains.", type=str,
                         default="resources/top1000_sublist.txt")
     parser.add_argument("-e", "--expand", help="Expand the target list recursively.", action="store_true",
@@ -225,6 +226,17 @@ def init_checks(master_switch, outpath):
 
     print(Style.RESET_ALL)
 
+    if args.proxy:
+        if args.proxy != "NoProxy":
+            #operating_system = os.popen('uname -a | cut -d " " -f 1').read()
+            try:
+                os.environ['http_proxy'] = args.proxy 
+                #os.environ['HTTP_PROXY'] = args.proxy
+                os.environ['https_proxy'] = args.proxy
+                #os.environ['HTTPS_PROXY'] = args.proxy
+            except:
+                exit(1)
+
     # Checks for a Internet Connection
     try:
         socket.setdefaulttimeout(5)
@@ -271,7 +283,10 @@ def asn_expansion(mswitch, hostx):
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'}
     api_endpoint = "https://api.bgpview.io/search?query_term=" + asn_query
     try:
-        response = requests.get(api_endpoint, headers=user_agent)
+        if 'http_proxy' in os.environ:
+            response = requests.get(api_endpoint, headers=user_agent,verify=False)
+        else:
+            response = requests.get(api_endpoint, headers=user_agent)
         api = json.loads(response.text)
     except:
         cprint("error", "Attack surface expansion failed.", 1)
@@ -314,8 +329,11 @@ def asn_expansion(mswitch, hostx):
         if len(asns) > 0:
             for asn in asns:
                 try:
-                    response2 = requests.get("https://api.bgpview.io/asn/{0}/prefixes".format(str(asn)),
-                                             headers=user_agent)
+                    if 'http_proxy' in os.environ:
+                        response2 = requests.get("https://api.bgpview.io/asn/{0}/prefixes".format(str(asn)),headers=user_agent,verify=False)
+                    else:
+                        response2 = requests.get("https://api.bgpview.io/asn/{0}/prefixes".format(str(asn)),headers=user_agent)
+
                     api2 = json.loads(response2.text)
                     # print(response2.text)
                     print(api2["data"]["ipv4_prefixes"])
@@ -427,61 +445,61 @@ def keyloader(keychain, master_switch):
         tmp = line.split()
         keychain[tmp[0]] = tmp[2].replace("\"", "")
 
-    print("{0}   HostHunter Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+    print("{0}   HostHunter Module  : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
     master_switch.hosthunter = True
 
     if args.screen_capture:
-        print("{0}   ScreenCapture Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   ScreenCapture Module   : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
         master_switch.screencapture = True
     else:
-        print("{0}   ScreenCapture Module	: [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   ScreenCapture Module   : [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
         master_switch.screencapture = False
-    print("{0}   DNSdumpster Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN + Style.BRIGHT, Fore.WHITE, Style.RESET_ALL))
-    print("{0}   URLScanIO Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+    print("{0}   DNSdumpster Module : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN + Style.BRIGHT, Fore.WHITE, Style.RESET_ALL))
+    print("{0}   URLScanIO Module   : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
 
     if len(keychain["linkedin_username"]) > 0 and len(keychain["linkedin_password"]) and args.linkedinner:
-        print("{0}   LinkedInner Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   LinkedInner Module : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
         master_switch.linkedinner = True
     else:
-        print("{0}   LinkedInner Module	: [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   LinkedInner Module : [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
         master_switch.linkedinner = False
 
     if len(keychain["hunterio"]) == 40:
-        print("{0}   HunterIO Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   HunterIO Module    : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
         master_switch.hunterio = True
     else:
-        print("{0}   HunterIO Module	: [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   HunterIO Module    : [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
         master_switch.hunterio = False
 
     if len(keychain["shodan"]) == 32:
-        print("{0}   Shodan Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   Shodan Module  : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
         master_switch.shodan = True
     else:
-        print("{0}   Shodan Module	: [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   Shodan Module  : [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
         master_switch.shodan = False
 
     if len(keychain["virustotal"]) == 64:
         print(
-            "{0}   VirusTotal Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+            "{0}   VirusTotal Module    : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
         master_switch.virustotal = True
     else:
         print(
-            "{0}   VirusTotal Module	: [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
+            "{0}   VirusTotal Module    : [{1}Disabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.RED, Fore.WHITE, Style.RESET_ALL))
         master_switch.virustotal = False
 
     if len(keychain["weleakinfo_priv"]) == 40:
         print(
-            "{0}   WeLeakInfo Module	: [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+            "{0}   WeLeakInfo Module    : [{1}Enabled{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
         master_switch.weleakinfo_private = True
     else:
-        print("   WeLeakInfo Module	: [Disabled]")
+        print("   WeLeakInfo Module : [Disabled]")
         master_switch.weleakinfo_private = False
 
     if args.expand:
-        print("{0}   SubHunter Module	: [{1}Recursive{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.YELLOW, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   SubHunter Module   : [{1}Recursive{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.YELLOW, Fore.WHITE, Style.RESET_ALL))
         master_switch.subhunter = True
     else:
-        print("{0}   SubHunter Module	: [{1}Active{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
+        print("{0}   SubHunter Module   : [{1}Active{2}]{3}".format(Fore.WHITE + Style.BRIGHT, Fore.GREEN, Fore.WHITE, Style.RESET_ALL))
 
 
 # msave Function - Store output in MongoDB [UAT]
@@ -673,7 +691,7 @@ def main(keychain, switch, output_path, count):
         cprint("red", target_list[key].primary_domain, 1)
 
         for ip in target_list[key].resolved_ips:
-            cprint("white", "	|", 1)
+            cprint("white", "   |", 1)
             cprint("white", "  [{0}]".format(ip.address), 1)
 
         if switch.expand is True:
@@ -848,16 +866,16 @@ def main(keychain, switch, output_path, count):
                 break
 
         if target_list[key].mx is not None:
-            cprint("white", " || MX Records	:", 1)
+            cprint("white", " || MX Records :", 1)
             for dt in target_list[key].mx:
                 cprint("info", str(dt.exchange), 1)
 
         if target_list[key].spf is not None:
             if target_list[key].spf:
                 print(
-                    " {0}|| SPF	: {1}".format(Fore.WHITE, Fore.GREEN + str(target_list[key].spf) + Style.RESET_ALL))
+                    " {0}|| SPF : {1}".format(Fore.WHITE, Fore.GREEN + str(target_list[key].spf) + Style.RESET_ALL))
             else:
-                print(" {0}|| SPF	: {1}".format(Fore.WHITE, Fore.RED + Style.BRIGHT + str(
+                print(" {0}|| SPF   : {1}".format(Fore.WHITE, Fore.RED + Style.BRIGHT + str(
                     target_list[key].spf) + Style.RESET_ALL))
 
         if len(target_list[key].dmarc) > 0:
@@ -880,19 +898,19 @@ def main(keychain, switch, output_path, count):
             print("")
             print(Fore.WHITE + " [-] IP Address: " + Style.BRIGHT + Fore.YELLOW + str(ip.address) + Style.RESET_ALL)
             if ip.hostname:
-                print(Fore.WHITE + " 	|| Hostname: " + Fore.YELLOW + ','.join(map(str, ip.hostname)) + Style.RESET_ALL)
+                print(Fore.WHITE + "    || Hostname: " + Fore.YELLOW + ','.join(map(str, ip.hostname)) + Style.RESET_ALL)
             if ip.server:
-                print(Fore.WHITE + " 	|| Server: " + Fore.YELLOW + ip.server)
+                print(Fore.WHITE + "    || Server: " + Fore.YELLOW + ip.server)
             if ip.ports:
-                print(Fore.WHITE + " 	|| Ports: " + Fore.YELLOW + '/tcp, '.join(map(str, ip.ports)) + "/tcp" + Style.RESET_ALL)
+                print(Fore.WHITE + "    || Ports: " + Fore.YELLOW + '/tcp, '.join(map(str, ip.ports)) + "/tcp" + Style.RESET_ALL)
             if ip.vulns:
-                print(Fore.WHITE + " 	|| Possible Vulnerabities: " + Fore.YELLOW + ','.join(map(str, ip.vulns)) + Style.RESET_ALL)
+                print(Fore.WHITE + "    || Possible Vulnerabities: " + Fore.YELLOW + ','.join(map(str, ip.vulns)) + Style.RESET_ALL)
             if ip.location:
-                print(Fore.WHITE + " 	|| Location: " + Fore.YELLOW + ip.location + Style.RESET_ALL)
-            print(Fore.WHITE + " 	|| ASN: " + Fore.YELLOW + ip.asn + Style.RESET_ALL)
+                print(Fore.WHITE + "    || Location: " + Fore.YELLOW + ip.location + Style.RESET_ALL)
+            print(Fore.WHITE + "    || ASN: " + Fore.YELLOW + ip.asn + Style.RESET_ALL)
             if ip.asn_name:
-                print(Fore.WHITE + " 	|| ASN Name: " + Fore.YELLOW + str(ip.asn_name) + Style.RESET_ALL)
-            print(Fore.WHITE + " 	|| CIDR: " + Fore.YELLOW + ip.cidr + Style.RESET_ALL)
+                print(Fore.WHITE + "    || ASN Name: " + Fore.YELLOW + str(ip.asn_name) + Style.RESET_ALL)
+            print(Fore.WHITE + "    || CIDR: " + Fore.YELLOW + ip.cidr + Style.RESET_ALL)
             print("")
             if ip.ports:
                 count.ports += len(ip.ports)
@@ -946,5 +964,12 @@ if __name__ == "__main__":
     main(keychain, sw1, output_path, c1)
 
     print_results(c1, start_time)  # Print terminal output
+
+    if args.proxy:
+        try:
+            del os.environ['http_proxy']
+            del os.environ['https_proxy']
+        except:
+            pass
 
     exit()

--- a/modules/buckethunter.py
+++ b/modules/buckethunter.py
@@ -1,13 +1,16 @@
 #!/usr/bin/python3
 #   Filename: buckethunter.py
 #   Module: BucketHunter
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 
 # External Libraries
 import colorama
 import requests
 from colorama import Fore, Style
 from tld import get_tld
+import traceback
+import os
+
 
 
 def cprint(type, msg, reset):
@@ -37,7 +40,12 @@ def passive_query(hostx, key):
     # print(keywords)
     par = {'access_token': key, 'keywords': keywords}
     try:
-        response = requests.get("https://buckets.grayhatwarfare.com/api/v1/buckets", params=par, timeout=4)
+        # Check if proxy is set, if it is dont verify ssl
+        if 'http_proxy' in os.environ:
+            response = requests.get("https://buckets.grayhatwarfare.com/api/v1/buckets", params=par, timeout=5,verify=False)
+        else:
+            response = requests.get("https://buckets.grayhatwarfare.com/api/v1/buckets", params=par, timeout=5)
+
         gwf_api = response.json()
 
         if gwf_api["buckets_count"] > 0:
@@ -49,11 +57,15 @@ def passive_query(hostx, key):
                 pass
 
     except:
-        cprint("error", "[*] Error: connecting with GrayHatWarfare API", 1)
+        cprint("error", "[*] Error: connecting with GrayHatWarfare API for Keywords Search", 1)
+        traceback.print_exc()
 
     par = {'access_token': key, 'keywords': hostx.orgName}
     try:
-        response = requests.get("https://buckets.grayhatwarfare.com/api/v1/buckets", params=par, timeout=4)
+        if 'http_proxy' in os.environ:
+            response = requests.get("https://buckets.grayhatwarfare.com/api/v1/buckets", params=par, timeout=5,verify=False)
+        else:
+            response = requests.get("https://buckets.grayhatwarfare.com/api/v1/buckets", params=par, timeout=5)
         gwf_api = response.json()
         if gwf_api["buckets_count"] > 0:
             try:
@@ -63,7 +75,8 @@ def passive_query(hostx, key):
                 pass
 
     except:
-        cprint("error", "[*] Error: connecting with GrayHatWarfare API", 1)
+        cprint("error", "[*] Error: connecting with GrayHatWarfare API for OrgName Search", 1)
+        traceback.print_exc()
 
 
 def active(mswitch, hostx, wordlist, recursive=False):

--- a/modules/dnsdumpster.py
+++ b/modules/dnsdumpster.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: dnsdumpster.py
 #   Module: DNSdumpster
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 
 # Standard Libraries
 import os
@@ -23,8 +23,10 @@ def get_map(hostx, out_path):
     if hostx.primary_domain == "":
         return None
     try:
-
-        res1 = requests.get(DNS_DUMPSTER, headers=headers)
+        if 'http_proxy' in os.environ:
+            res1 = requests.get(DNS_DUMPSTER, headers=headers,verify=False)
+        else:
+            res1 = requests.get(DNS_DUMPSTER, headers=headers)
         csrftoken = res1.cookies.get('csrftoken')
         data = {
             'csrfmiddlewaretoken': csrftoken,
@@ -33,9 +35,12 @@ def get_map(hostx, out_path):
 
         headers = {'user-agent': "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0",
                    'Referer': DNS_DUMPSTER, 'Cookie': 'csrftoken=' + csrftoken}
-        res2 = requests.post(DNS_DUMPSTER, data=data, headers=headers)
-
-        response = requests.get(map_url, headers=headers)
+        if 'http_proxy' in os.environ:
+            res2 = requests.post(DNS_DUMPSTER, data=data, headers=headers,verify=False)
+            response = requests.get(map_url, headers=headers,verify=False)
+        else:
+            res2 = requests.post(DNS_DUMPSTER, data=data, headers=headers)
+            response = requests.get(map_url, headers=headers)
         # print("Response Status: " + response.status_code) # Debug Statement
         if response.status_code == 200:
 

--- a/modules/hunterio.py
+++ b/modules/hunterio.py
@@ -9,6 +9,7 @@ import json
 
 # External Libraries
 import requests
+import os
 
 
 def query(hostx, key):
@@ -16,7 +17,10 @@ def query(hostx, key):
         domain = hostx.primary_domain
         par = {'domain': domain, 'api_key': key}
         user_agent = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'}
-        req = requests.get("https://api.hunter.io/v2/domain-search", params=par, headers=user_agent)
+        if 'http_proxy' in os.environ:
+            req = requests.get("https://api.hunter.io/v2/domain-search", params=par, headers=user_agent,verify=False)
+        else:
+            req = requests.get("https://api.hunter.io/v2/domain-search", params=par, headers=user_agent)
         hunterio_api = json.loads(req.text)
 
         try:

--- a/modules/hunterio.py
+++ b/modules/hunterio.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: hunterio.py
 #   Module: HunterIO
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 # https://api.hunter.io/v2/domain-search?domain=
 
 # Standard Libraries

--- a/modules/linkedinner.py
+++ b/modules/linkedinner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: linkedinner.py
 #   Module: LinkedInner 
-#   Author: Jacob Wilkin & Andreas Georgiou (@superhedgy)
+#   Author: Jacob Wilkin (Greenwolf @jacob_wilkin) & Andreas Georgiou (@superhedgy)
 #   Credits: linkedint & @greenwolf
 
 # Standard Libraries

--- a/modules/linkedinner.py
+++ b/modules/linkedinner.py
@@ -91,7 +91,11 @@ def get_emails_for_company_name(mswitch, hostx, linkedin_username, linkedin_pass
         url = "https://www.linkedin.com/voyager/api/typeahead/hits?q=blended&query=%s" % company_name
         headers = {'Csrf-Token': 'ajax:0397788525211216808', 'X-RestLi-Protocol-Version': '2.0.0'}
         cookies['JSESSIONID'] = 'ajax:0397788525211216808'
-        r = requests.get(url, cookies=cookies, headers=headers)
+        if 'http_proxy' in os.environ:
+            r = requests.get(url, cookies=cookies, headers=headers,verify=False)
+        else:
+            r = requests.get(url, cookies=cookies, headers=headers)
+
         content = json.loads(r.text)
         firstID = 0
         for i in range(0, len(content['elements'])):
@@ -113,7 +117,10 @@ def get_emails_for_company_name(mswitch, hostx, linkedin_username, linkedin_pass
         company_id)
     headers = {'Csrf-Token': 'ajax:0397788525211216808', 'X-RestLi-Protocol-Version': '2.0.0'}
     cookies['JSESSIONID'] = 'ajax:0397788525211216808'
-    r = requests.get(url, cookies=cookies, headers=headers)
+    if 'http_proxy' in os.environ:
+        r = requests.get(url, cookies=cookies, headers=headers,verify=False)
+    else:
+        r = requests.get(url, cookies=cookies, headers=headers)
     content = json.loads(r.text)
     data_total = content['elements'][0]['total']
 
@@ -141,7 +148,10 @@ def get_emails_for_company_name(mswitch, hostx, linkedin_username, linkedin_pass
     for p in range(pages):
         url = "https://www.linkedin.com/voyager/api/search/cluster?count=40&guides=List(v->PEOPLE,facetCurrentCompany->%s)&origin=OTHER&q=guided&start=%i" % (
             company_id, p * 40)
-        r = requests.get(url, cookies=cookies, headers=headers)
+        if 'http_proxy' in os.environ:
+            r = requests.get(url, cookies=cookies, headers=headers,verify=False)
+        else:
+            r = requests.get(url, cookies=cookies, headers=headers)
         content = r.text.encode('UTF-8')
         content = json.loads(content)
 

--- a/modules/linkedinner.py
+++ b/modules/linkedinner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #   Filename: linkedinner.py
-#   Module: LinkedInner
+#   Module: LinkedInner 
 #   Author: Jacob Wilkin & Andreas Georgiou (@superhedgy)
 #   Credits: linkedint & @greenwolf
 

--- a/modules/shodan.py
+++ b/modules/shodan.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 #   Filename: shodan.py
 #   Module: Shodan
-#   Authors: Andreas Georgiou (@superhedgy)
-#            Jacob Wilkin (@greenwolf)
+#   Authors: Jacob Wilkin (Greenwolf @jacob_wilkin)
+#            Andreas Georgiou (@superhedgy)
 
 # Standard Libraries
 import time
@@ -12,7 +12,16 @@ import shodan
 
 
 def port_scan(hostx, key, counter):
-    api = shodan.Shodan(key)
+    if 'http_proxy' in os.environ:
+        try:
+            proxy_dict = {'https':os.environ['http_proxy']}
+            #proxy_dict = {'http':os.environ['http_proxy'],'https':os.environ['http_proxy']}
+            #print(proxy_dict)
+            api = shodan.Shodan(key,proxies=proxy_dict)
+        except:
+            traceback.print_exc()
+    else:
+        api = shodan.Shodan(key)
     numports = 0
 
     for IP in hostx.resolved_ips:

--- a/modules/subhunter.py
+++ b/modules/subhunter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: subhunter.py
 #   Module: SubHunter
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 
 # Standard Libraries
 import colorama
@@ -12,6 +12,7 @@ from colorama import Fore, Style
 from validator_collection import checkers
 
 from modules import subbrute
+import os
 
 
 class TargetIP:
@@ -53,7 +54,12 @@ def cprint(type, msg, reset):
 def passive_query(hostx, key):
     par = {'apikey': key, 'domain': hostx.primary_domain}
     try:
-        response = requests.get("https://www.virustotal.com/vtapi/v2/domain/report", params=par, timeout=4)
+        if 'http_proxy' in os.environ:
+            response = requests.get("https://www.virustotal.com/vtapi/v2/domain/report", params=par, timeout=4,verify=False)
+        else:
+            response = requests.get("https://www.virustotal.com/vtapi/v2/domain/report", params=par, timeout=4)
+
+
         tv_api = response.json()
 
         try:

--- a/modules/urlscanio.py
+++ b/modules/urlscanio.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: urlscanio.py
 #   Module: URLScanIO Module
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 
 # Standard Libraries
 import json
@@ -10,7 +10,7 @@ import json
 import requests
 
 import asm
-
+import os
 
 def get_domain(IP):
     # print (ip.address)
@@ -18,7 +18,10 @@ def get_domain(IP):
     user_agent = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'}
     try:
-        response = requests.get('https://urlscan.io/api/v1/search?q=ip:' + IP, headers=user_agent)
+        if 'http_proxy' in os.environ:
+            response = requests.get('https://urlscan.io/api/v1/search?q=ip:' + IP, headers=user_agent,verify=False)
+        else:
+            response = requests.get('https://urlscan.io/api/v1/search?q=ip:' + IP, headers=user_agent)
         api = json.loads(response.text)
         if api['total'] == 0:
             return
@@ -39,7 +42,10 @@ def query(hostx):
         user_agent = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'}
         try:
-            response = requests.get("https://urlscan.io/api/v1/search", params=par, headers=user_agent)
+            if 'http_proxy' in os.environ:
+                response = requests.get("https://urlscan.io/api/v1/search", params=par, headers=user_agent,verify=False)
+            else:
+                response = requests.get("https://urlscan.io/api/v1/search", params=par, headers=user_agent)
             # print(response.status_code)
             # print(response.text)
             api = json.loads(response.text)

--- a/modules/webscraper.py
+++ b/modules/webscraper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: webscraper.py
 #   Module: webscraper
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 
 # Standard Libraries
 import re

--- a/modules/webscraper.py
+++ b/modules/webscraper.py
@@ -9,7 +9,7 @@ import re
 # External Libraries
 import requests
 from bs4 import BeautifulSoup
-
+import os
 
 def extract_info(hostx):
     print("webscraper Enabled")
@@ -17,7 +17,10 @@ def extract_info(hostx):
     user_agent = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'}
     try:
-        response = requests.get(url, headers=user_agent)
+        if 'http_proxy' in os.environ:
+            response = requests.get(url, headers=user_agent,verify=False)
+        else:
+            response = requests.get(url, headers=user_agent)
 
         html_response = BeautifulSoup(response.text, 'html.parser')
 

--- a/modules/webscraper.py
+++ b/modules/webscraper.py
@@ -5,7 +5,7 @@
 
 # Standard Libraries
 import re
-
+ 
 # External Libraries
 import requests
 from bs4 import BeautifulSoup

--- a/modules/weleakinfo.py
+++ b/modules/weleakinfo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #   Filename: weleakinfo.py
 #   Module: WeLeakInfo Module
-#   Author: Andreas Georgiou (@superhedgy)
+#   Author: Andreas Georgiou (@superhedgy) & Jacob Wilkin (Greenwolf @jacob_wilkin)
 
 # Standard Libraries
 import json

--- a/modules/weleakinfo.py
+++ b/modules/weleakinfo.py
@@ -12,7 +12,7 @@ import traceback
 import requests
 
 import asm
-
+import os
 
 def query(hostx, api_key, priv_key):
     head = {
@@ -27,7 +27,10 @@ def query(hostx, api_key, priv_key):
     for email in hostx.emails:
         try:
             url = "https://api.weleakinfo.com/v3/public/email/" + email
-            response = requests.get(url, headers=head)
+            if 'http_proxy' in os.environ:
+                response = requests.get(url, headers=head,verify=False)
+            else:
+                response = requests.get(url, headers=head)
 
             if not (response.status_code == 200):
                 return -1


### PR DESCRIPTION
Implemented Proxy Support.

Workarounds were:
- For HTTP proxies, SSL cert verification is disabled. This is so it can be MITM'd in Burp for debugging.
- For localhost proxies, MITM works for everything except the Shodan module. 

Might be worth splitting into proxy & debugging mode in the future. For now only use trusted proxies.